### PR TITLE
store function result in variable

### DIFF
--- a/Examples/CLI_Welcome_API_Example.php
+++ b/Examples/CLI_Welcome_API_Example.php
@@ -55,7 +55,8 @@ foreach($homes as $home)
 
 $home = $homes[0];
 $tz = $home->getTimezone();
-if(!empty($home->getPersons()))
+$persons = $home->getPersons();
+if(!empty($persons))
 {
     $known = $home->getKnownPersons();
     $person = $known[0];


### PR DESCRIPTION
instead using inline of an IF, because WordPress does not allow this.