### PR TITLE
Removing empty() from Utils.php in the examples

### DIFF
--- a/Examples/Utils.php
+++ b/Examples/Utils.php
@@ -237,7 +237,7 @@ function printHomeInformation(NAHome $home)
     $tz = $home->getTimezone();
     $persons = $home->getPersons();
 	
-    if(!empty($persons))
+    if ($persons)
     {
         printMessageWithBorder("Persons");
         //print person list
@@ -247,7 +247,7 @@ function printHomeInformation(NAHome $home)
         }
     }
 
-    if((!empty($home->getEvents())))
+    if ($home->getEvents())
     {
         printMessageWithBorder('Timeline of Events');
         //print event list
@@ -257,7 +257,7 @@ function printHomeInformation(NAHome $home)
         }
     }
 
-    if(!empty($home->getCameras()))
+    if ($home->getCameras()) 
     {
         printMessageWithBorder("Cameras");
         foreach($home->getCameras() as $camera)


### PR DESCRIPTION
When executed on my environment, I kept having errors  provoked by the use of `empty()` : 
>  "PHP Fatal error:  Can't use method return value in write context".



Relevant discussion on [Stackoverflow](http://stackoverflow.com/a/4328049)